### PR TITLE
Add notebook for loading results

### DIFF
--- a/notebooks/01_carregamento_exploracao.ipynb
+++ b/notebooks/01_carregamento_exploracao.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Solicita o upload manual do arquivo results.csv e carrega com pandas\n",
+    "from google.colab import files\n",
+    "uploaded = files.upload()  # O usuário seleciona o arquivo results.csv\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Carregamento do arquivo enviado\n",
+    "df = pd.read_csv('results.csv')\n",
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Exibe as 5 primeiras linhas e um resumo estatístico dos dados numéricos\n",
+    "print(df.head())\n",
+    "print(df.describe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Os dados representam os resultados de corridas de Fórmula 1 de 1950 a 2020. Cada linha \u00e9 a classificação de um piloto em uma corrida, contendo informações como posição, pontos, tempo e volta mais rápida."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- add Colab notebook to load results.csv and show quick stats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684758bfae6c832b8aca2a8b5f39eda8